### PR TITLE
Chore/#1 common init

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java-library'   //api()를 사용하기 위한 플러그인
-    id 'maven-publish'
     id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -42,7 +41,7 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     api 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
-    api "org.springframework.boot:spring-boot-starter-aop:4.0.0-M2"
+    api "org.springframework.boot:spring-boot-starter-aop"
     api "io.github.resilience4j:resilience4j-spring-boot3:2.2.0"
     api 'io.github.resilience4j:resilience4j-circuitbreaker'
     api 'io.github.resilience4j:resilience4j-retry'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java'
+    id 'java-library'   //api()를 사용하기 위한 플러그인
+    id 'maven-publish'
     id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -14,16 +15,74 @@ java {
     }
 }
 
+bootJar { enabled = false }
+jar {
+    enabled = true
+    archiveClassifier.set('') // 일반 jar 생성
+}
+
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+}
+
+ext {
+    set('springCloudVersion', "2025.1.1")
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    api 'org.springframework.boot:spring-boot-starter-validation'
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    api 'org.springframework.kafka:spring-kafka'
+    api 'org.springframework.boot:spring-boot-starter-security'
+    api 'org.springframework.boot:spring-boot-starter-web'
+    api 'org.springframework.cloud:spring-cloud-starter-config'
+    api 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
+    api 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    api 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    api 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    api "org.springframework.boot:spring-boot-starter-aop:4.0.0-M2"
+    api "io.github.resilience4j:resilience4j-spring-boot3:2.2.0"
+    api 'io.github.resilience4j:resilience4j-circuitbreaker'
+    api 'io.github.resilience4j:resilience4j-retry'
+
+    api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
+
+//    api "com.github.danielwegener:logback-kafka-appender:0.2.0-RC2"
+//    api 'net.logstash.logback:logstash-logback-encoder:7.4'
+
+//    // Zipkin
+//    api 'io.micrometer:micrometer-tracing-bridge-brave'
+//    api 'io.zipkin.reporter2:zipkin-reporter-brave'
+//    api 'io.github.openfeign:feign-micrometer'
+
+    api 'io.github.openfeign.querydsl:querydsl-jpa:6.8'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.8'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+clean {
+    delete querydslDir
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
+#Thu Apr 23 11:35:00 KST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
-networkTimeout=10000
-validateDistributionUrl=true
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/pgsg/common/domain/BaseEntity.java
+++ b/src/main/java/org/pgsg/common/domain/BaseEntity.java
@@ -1,0 +1,59 @@
+package org.pgsg.common.domain;
+
+import java.time.LocalDateTime;
+
+import org.pgsg.common.util.SecurityUtil;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.util.StringUtils;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedBy
+	@Column(length=45, updatable = false)
+	protected String createdBy;
+
+	@CreatedDate
+	@Column(updatable = false)
+	protected LocalDateTime createdAt;
+
+	@LastModifiedBy
+	@Column(length=45, insertable = false)
+	protected String modifiedBy;
+
+	@LastModifiedDate
+	@Column(insertable = false)
+	protected LocalDateTime modifiedAt;
+
+	@Column(length=45, insertable = false)
+	protected String deletedBy;
+
+	protected LocalDateTime deletedAt;
+
+	protected void delete(String deletedBy) {
+		// 이미 삭제된 경우 중복 처리 방지
+		if (this.deletedAt != null) {
+			return;
+		}
+
+		this.deletedBy = StringUtils.hasText(deletedBy)
+			? deletedBy
+			: SecurityUtil.getCurrentUsername().orElse("SYSTEM");	//todo: securityUtil 완성 후 검토
+
+		this.deletedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/org/pgsg/common/domain/BaseEntity.java
+++ b/src/main/java/org/pgsg/common/domain/BaseEntity.java
@@ -1,6 +1,7 @@
 package org.pgsg.common.domain;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import org.pgsg.common.util.SecurityUtil;
 import org.springframework.data.annotation.CreatedBy;
@@ -24,35 +25,31 @@ import lombok.Getter;
 public abstract class BaseEntity {
 
 	@CreatedBy
-	@Column(length=45, updatable = false)
-	protected String createdBy;
+	@Column(updatable = false)
+	protected UUID createdBy;
 
 	@CreatedDate
 	@Column(updatable = false)
 	protected LocalDateTime createdAt;
 
 	@LastModifiedBy
-	@Column(length=45, insertable = false)
-	protected String modifiedBy;
+	@Column(insertable = false)
+	protected UUID modifiedBy;
 
 	@LastModifiedDate
 	@Column(insertable = false)
 	protected LocalDateTime modifiedAt;
 
-	@Column(length=45, insertable = false)
-	protected String deletedBy;
+	@Column(insertable = false)
+	protected UUID deletedBy;
 
 	protected LocalDateTime deletedAt;
 
-	protected void delete(String deletedBy) {
+	protected void delete(UUID deletedBy) {
 		// 이미 삭제된 경우 중복 처리 방지
-		if (this.deletedAt != null) {
-			return;
-		}
-
-		this.deletedBy = StringUtils.hasText(deletedBy)
+		this.deletedBy = deletedBy!=null
 			? deletedBy
-			: SecurityUtil.getCurrentUsername().orElse("SYSTEM");	//todo: securityUtil 완성 후 검토
+			: SecurityUtil.getCurrentUserId().orElse(UUID.fromString("00000000-0000-0000-0000-00000000000"));
 
 		this.deletedAt = LocalDateTime.now();
 	}

--- a/src/main/java/org/pgsg/common/messaging/annotation/IdempotentConsumer.java
+++ b/src/main/java/org/pgsg/common/messaging/annotation/IdempotentConsumer.java
@@ -1,0 +1,12 @@
+package org.pgsg.common.messaging.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IdempotentConsumer {
+	String value(); // 메세지 그룹
+}

--- a/src/main/java/org/pgsg/common/util/JsonUtil.java
+++ b/src/main/java/org/pgsg/common/util/JsonUtil.java
@@ -1,0 +1,45 @@
+package org.pgsg.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Slf4j
+public class JsonUtil {
+	private static ObjectMapper objectMapper;
+
+
+	@Autowired
+	public void init(ObjectMapper objectMapper) {
+		JsonUtil.objectMapper = objectMapper;
+	}
+
+	public static String toJson(Object obj) {
+		try {
+			return objectMapper.writeValueAsString(obj);
+		} catch (JsonProcessingException e) {
+			log.error("JSON 변환 실패: {}", e.getMessage(), e);
+			return null;
+		}
+	}
+
+	public static <T> T fromJson(String json, Class<T> clazz) {
+		try {
+			return objectMapper.readValue(json, clazz);
+		} catch (JsonProcessingException e) {
+			log.error("Java 객체 변환(Class) 실패: {}", e.getMessage(), e);
+			return null;
+		}
+	}
+
+	public static <T> T fromJson(String json, TypeReference<T> typeReference) {
+		try {
+			return objectMapper.readValue(json, typeReference);
+		} catch (JsonProcessingException e) {
+			log.error("Java 객체 변환(TypeReference) 실패: {}", e.getMessage(), e);
+			return null;
+		}
+	}
+}

--- a/src/main/java/org/pgsg/common/util/JsonUtil.java
+++ b/src/main/java/org/pgsg/common/util/JsonUtil.java
@@ -3,22 +3,29 @@ package org.pgsg.common.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class JsonUtil {
-	private static ObjectMapper objectMapper;
 
+	private final ObjectMapper objectMapper;
+	private static ObjectMapper mapper;
 
-	@Autowired
-	public void init(ObjectMapper objectMapper) {
-		JsonUtil.objectMapper = objectMapper;
+	@PostConstruct
+	public void init() {
+		mapper = this.objectMapper;
 	}
 
 	public static String toJson(Object obj) {
 		try {
-			return objectMapper.writeValueAsString(obj);
+			return mapper.writeValueAsString(obj);
 		} catch (JsonProcessingException e) {
 			log.error("JSON 변환 실패: {}", e.getMessage(), e);
 			return null;
@@ -27,7 +34,7 @@ public class JsonUtil {
 
 	public static <T> T fromJson(String json, Class<T> clazz) {
 		try {
-			return objectMapper.readValue(json, clazz);
+			return mapper.readValue(json, clazz);
 		} catch (JsonProcessingException e) {
 			log.error("Java 객체 변환(Class) 실패: {}", e.getMessage(), e);
 			return null;
@@ -36,7 +43,7 @@ public class JsonUtil {
 
 	public static <T> T fromJson(String json, TypeReference<T> typeReference) {
 		try {
-			return objectMapper.readValue(json, typeReference);
+			return mapper.readValue(json, typeReference);
 		} catch (JsonProcessingException e) {
 			log.error("Java 객체 변환(TypeReference) 실패: {}", e.getMessage(), e);
 			return null;

--- a/src/main/java/org/pgsg/common/util/MdcTaskDecorator.java
+++ b/src/main/java/org/pgsg/common/util/MdcTaskDecorator.java
@@ -16,6 +16,8 @@ public class MdcTaskDecorator implements TaskDecorator {
 				// 새로운 (자식) 쓰레드에 복사해둔 컨텍스트 주입
 				if (contextMap != null) {
 					MDC.setContextMap(contextMap);
+				}else{
+					MDC.clear();
 				}
 
 				runnable.run();

--- a/src/main/java/org/pgsg/common/util/MdcTaskDecorator.java
+++ b/src/main/java/org/pgsg/common/util/MdcTaskDecorator.java
@@ -1,0 +1,28 @@
+package org.pgsg.common.util;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+import java.util.Map;
+
+public class MdcTaskDecorator implements TaskDecorator {
+	@Override
+	public Runnable decorate(Runnable runnable) {
+		// 현재(부모) 쓰레드의 MDC 컨텍스트 맵을 복사
+		Map<String, String> contextMap = MDC.getCopyOfContextMap();
+
+		return () -> {
+			try {
+				// 새로운 (자식) 쓰레드에 복사해둔 컨텍스트 주입
+				if (contextMap != null) {
+					MDC.setContextMap(contextMap);
+				}
+
+				runnable.run();
+			} finally {
+				// 자식 쓰레드 작업 종료 후 반드시 비우기 (쓰레드 풀 오염 방지)
+				MDC.clear();
+			}
+		};
+	}
+}

--- a/src/main/java/org/pgsg/common/util/SecurityUtil.java
+++ b/src/main/java/org/pgsg/common/util/SecurityUtil.java
@@ -1,0 +1,33 @@
+package org.pgsg.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.pgsg.common.exception.UnAuthorizedException;
+import org.pgsg.config.security.UserDetailsImpl;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SecurityUtil {
+	public static Optional<UserDetailsImpl> getCurrentUser() {	//todo: config 설정 후 다시 확인
+		return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+			.map(Authentication::getPrincipal)
+			.filter(principal -> principal instanceof UserDetailsImpl)
+			.map(UserDetailsImpl.class::cast);
+	}
+
+	public static Optional<UUID> getCurrentUserId() {
+		return getCurrentUser().map(UserDetailsImpl::getUuid);
+	}
+
+	public static UUID getCurrentUserIdOrThrow() {
+		return getCurrentUserId().orElseThrow(UnAuthorizedException::new);	//todo: 공통 예외 설정 후 수정여부 확인
+	}
+
+	public static Optional<String> getCurrentUsername() {
+		return getCurrentUser().map(UserDetailsImpl::getUsername);
+	}
+}


### PR DESCRIPTION
### 작업 배경
- 개별 서비스 작업 전 공통 모듈 추가를 위해 초기 버전의 파일을 추가했습니다.

### 작업 내용
- common 하위 파일 중 mvp에 필요하다 판단되는 부분만 추가
- 공통 필요 의존성 추가

### 테스트 여부
- 단순 파일 추가라 테스트는 작성하지 않았습니다.

### 기타
- 의존성 일부 변경 및 주석처리한 부분 말고는 거의 수정한 부분이 없습니다. 혹시 수정 필요한 부분 발견하시면 알려주세요!
- 파일 중 일부에 config 및 공통 예외 처리 부분이 필요한 부분이 있어 해당 부분은 추후 추가 후에 다시 수정하겠습니다!

### 이슈
> #1 [CHORE] 공통 모듈 초기 세팅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 엔티티에 생성/수정 일시 및 사용자 추적 기능 추가
  * 안전한 소프트 삭제 지원 추가
  * 멱등성 있는 메시지 처리 어노테이션 추가
  * JSON 직렬화/역직렬화 유틸리티 추가
  * 스레드 간 MDC 전파용 작업 데코레이터 추가
  * 현재 사용자 정보 접근 유틸리티 추가

* **Chores**
  * 빌드 도구 업그레이드 및 구성 변경 (Gradle 8.14.4 → 9.3.0)  
  * 엔터프라이즈 의존성 집합 확장 (Spring Cloud, OAuth2, OpenFeign 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->