### PR TITLE
fix: AuditorAware 반환타입 수정 및 내부 로직 보강

### DIFF
--- a/src/main/java/org/pgsg/config/security/SecurityConfigImpl.java
+++ b/src/main/java/org/pgsg/config/security/SecurityConfigImpl.java
@@ -16,6 +16,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Optional;
+import java.util.UUID;
+
 @Slf4j
 @Configuration
 @EnableWebSecurity
@@ -52,8 +55,12 @@ public class SecurityConfigImpl implements SecurityConfig {
     }
 
     @Bean
-    public AuditorAware<String> auditorProvider() {
-        return SecurityUtil::getCurrentUsername;
+    public AuditorAware<UUID> auditorProvider() {
+        // 시스템 기본값으로 사용할 UUID (예: 관리자나 시스템 계정 ID)
+        UUID DEFAULT_SYSTEM_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+        return () -> SecurityUtil.getCurrentUserId()
+                .or(() -> Optional.of(DEFAULT_SYSTEM_ID)); // null(empty)이면 기본값 포함된 Optional 반환
     }
 
     @Bean


### PR DESCRIPTION
### 작업 배경
- 회원가입 기능 테스트 중 AuditorAware가 createdBy에 UUID 대신 String을 할당하면서 타입 오류로 인한 500 에러 발생

### 작업 내용
- SecurityConfigImpl 내 AuditorAware의 반환타입을 AuditorAware<String>에서 AuditorAware<UUID>로 변경하여 createdBy, modifiedBy와의 타입 불일치 문제 해결
- 회원가입의 경우 로그인하지 않은 상태에서 진행되므로 createdBy를 null로 두는 대신 UUID 상수인 DEFAULT_SYSTEM_ID를 반환하도록 내부 로직 수정

### 테스트 여부
- 코드 수정 후 `gradle clean build` 정상 완료됨을 확인 

### 기타
- @Jin4041  build.gradle 기준 버그 수정 작업을 진행한 버전은 0.0.1-SNAPSHOT입니다.

### 이슈
- This closes #11 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 감시 기능의 신뢰성을 개선했습니다. 사용자 식별 정보가 없는 경우에도 시스템 기본값으로 감시 데이터가 정상적으로 기록되도록 처리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->