### PR TITLE
[FEAT] 공통 예외 처리 모듈 Enum 기반 리팩토링 및 ErrorCode 추상화 (v0.1.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'org.pgsg'
-version = '0.0.1-SNAPSHOT'
+version = '0.1.0-SNAPSHOT'
 description = 'common'
 
 java {

--- a/src/main/java/org/pgsg/common/exception/CustomException.java
+++ b/src/main/java/org/pgsg/common/exception/CustomException.java
@@ -5,16 +5,15 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
 
-	private final String errorName;	//YAML 파일의 key(예외명)
+	private final ErrorCode errorCode;
 	private final String field;	//예외가 발생한 필드
 
-	public CustomException(String errorName){
-		this(errorName, null);
+	public CustomException(ErrorCode errorCode) {
+		this(errorCode, null);
 	}
 
-	public CustomException(String errorName, String field) {
-		super(errorName);
-		this.errorName = errorName;
+	public CustomException(ErrorCode errorCode, String field) {
+        this.errorCode = errorCode;
 		this.field = field;
 	}
 }

--- a/src/main/java/org/pgsg/common/exception/ErrorCode.java
+++ b/src/main/java/org/pgsg/common/exception/ErrorCode.java
@@ -1,0 +1,5 @@
+package org.pgsg.common.exception;
+
+public interface ErrorCode {
+    String getErrorKey();
+}

--- a/src/main/java/org/pgsg/common/exception/ErrorConfigProperties.java
+++ b/src/main/java/org/pgsg/common/exception/ErrorConfigProperties.java
@@ -1,25 +1,26 @@
 package org.pgsg.common.exception;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import lombok.Getter;
-import lombok.Setter;
+import java.util.HashMap;
+import java.util.Map;
 
 @Getter
 @Setter
 @Component
 @ConfigurationProperties(prefix = "error")
 public class ErrorConfigProperties {
-	private Map<String ,ErrorDetail> configs=new HashMap<>();
 
-	@Getter @Setter
+	private Map<String, ErrorDetail> configs = new HashMap<>();
+
+	@Getter
+	@Setter
 	public static class ErrorDetail {
 		private String code;
-		private String message;
 		private int status;
+		private String message;
 	}
 }

--- a/src/main/java/org/pgsg/common/exception/GlobalErrorCode.java
+++ b/src/main/java/org/pgsg/common/exception/GlobalErrorCode.java
@@ -1,0 +1,17 @@
+package org.pgsg.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+    ACCESS_DENIED("AccessDeniedException"),
+    UNAUTHORIZED("UnauthorizedException"),
+
+    ;
+
+    private final String errorKey;
+
+}

--- a/src/main/java/org/pgsg/common/exception/GlobalErrorCode.java
+++ b/src/main/java/org/pgsg/common/exception/GlobalErrorCode.java
@@ -7,11 +7,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
 
+    // Security & Auth
     ACCESS_DENIED("AccessDeniedException"),
     UNAUTHORIZED("UnauthorizedException"),
 
+    // Validation & Request
+    INVALID_INPUT_VALUE("MethodArgumentNotValidException"),
+    METHOD_NOT_ALLOWED("HttpRequestMethodNotSupportedException"),
+
+    // Resource
+    ENTITY_NOT_FOUND("EntityNotFoundException"),
+
+    // Server Error
+    INTERNAL_SERVER_ERROR("RuntimeException"),
+    GATEWAY_TIMEOUT("GatewayTimeoutException"),
     ;
 
     private final String errorKey;
-
 }

--- a/src/main/java/org/pgsg/common/exception/GlobalExceptionAdviceImpl.java
+++ b/src/main/java/org/pgsg/common/exception/GlobalExceptionAdviceImpl.java
@@ -40,26 +40,27 @@ public class GlobalExceptionAdviceImpl implements GlobalExceptionAdvice {
 
 		return ResponseEntity
 				.status(status)
-				.body(ErrorResponse.of(status, e.getField(), detail.getMessage()));
+				.body(ErrorResponse.of(status, detail.getCode(), detail.getMessage()));
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
 		log.error("[TraceID: {}] MethodArgumentNotValidException: {}",
 				MDC.get("traceId"), e.getMessage(), e);
+		
+		ErrorDetail detail = errorConfigProperties.getConfigs().get(GlobalErrorCode.INVALID_INPUT_VALUE.getErrorKey());
 
 		return ResponseEntity
 				.status(HttpStatus.BAD_REQUEST)
-				.body(ErrorResponse.of(HttpStatus.BAD_REQUEST, null, "잘못된 입력값입니다."));
+				.body(ErrorResponse.of(HttpStatus.BAD_REQUEST, detail.getCode(), detail.getMessage()));
 	}
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception e) {
-		log.error("[TraceID: {}] Exception: {}",
-				MDC.get("traceId"), e.getMessage(), e);
+		ErrorDetail detail = errorConfigProperties.getConfigs().get(GlobalErrorCode.INTERNAL_SERVER_ERROR.getErrorKey());
 
 		return ResponseEntity
 				.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, null, "서버 내부 오류가 발생했습니다."));
+				.body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, detail.getCode(), detail.getMessage()));
 	}
 }

--- a/src/main/java/org/pgsg/common/exception/GlobalExceptionAdviceImpl.java
+++ b/src/main/java/org/pgsg/common/exception/GlobalExceptionAdviceImpl.java
@@ -5,6 +5,7 @@ import org.pgsg.common.response.ErrorResponse;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,29 +21,45 @@ public class GlobalExceptionAdviceImpl implements GlobalExceptionAdvice {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-		// YAML에서 공통 정보 가져옴
-		ErrorDetail detail=errorConfigProperties.getConfigs().get(e.getErrorName());
-		
-		//yaml에서 정의하지 않은 에러 발생
+		String errorKey = e.getErrorCode().getErrorKey();
+		ErrorDetail detail = errorConfigProperties.getConfigs().get(errorKey);
+
 		if (detail == null) {
-			log.error("[TraceID: {}] 정의되지 않은 에러: {}", MDC.get("traceId"), e.getErrorName());
+			log.error("[TraceID: {}] Undefined Error Key: field={}, errorKey={}",
+					MDC.get("traceId"), e.getField(), errorKey, e);
+
 			return ResponseEntity
-				.status(HttpStatus.INTERNAL_SERVER_ERROR) // 500
-				.body(ErrorResponse.of(
-					HttpStatus.valueOf(500),                    	// errorCode (상태코드와 동일하게 혹은 "SYSTEM_ERROR")
-					e.getField(),           								// 어떤 필드에서 터졌는지 (예외에 담긴 값)
-					"서버 내부 오류가 발생했습니다." // 상세 메시지
-				));
+					.status(HttpStatus.INTERNAL_SERVER_ERROR)
+					.body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getField(), "정의되지 않은 서버 에러가 발생했습니다."));
 		}
 
-		int httpStatus=detail.getStatus();
-		
-		// MDC에서 traceId를 가져와 로그에 명시적으로 출력
-		log.error("[TraceID: {}] Custom Exception: {}", MDC.get("traceId"), e.getMessage(), e);
+		log.error("[TraceID: {}] CustomException: field={}, errorKey={}, message={}",
+				MDC.get("traceId"), e.getField(), errorKey, detail.getMessage(), e);
+
+		HttpStatus status = HttpStatus.valueOf(detail.getStatus());
 
 		return ResponseEntity
-			.status(httpStatus)
-			.body(ErrorResponse.of(HttpStatus.valueOf(httpStatus), e.getField(), detail.getMessage()));
+				.status(status)
+				.body(ErrorResponse.of(status, e.getField(), detail.getMessage()));
 	}
 
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+		log.error("[TraceID: {}] MethodArgumentNotValidException: {}",
+				MDC.get("traceId"), e.getMessage(), e);
+
+		return ResponseEntity
+				.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorResponse.of(HttpStatus.BAD_REQUEST, null, "잘못된 입력값입니다."));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception e) {
+		log.error("[TraceID: {}] Exception: {}",
+				MDC.get("traceId"), e.getMessage(), e);
+
+		return ResponseEntity
+				.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, null, "서버 내부 오류가 발생했습니다."));
+	}
 }

--- a/src/main/java/org/pgsg/common/util/SecurityUtil.java
+++ b/src/main/java/org/pgsg/common/util/SecurityUtil.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.pgsg.common.exception.CustomException;
+import org.pgsg.common.exception.GlobalErrorCode;
 import org.pgsg.config.security.UserDetailsImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -26,8 +27,7 @@ public class SecurityUtil {
 	}
 
 	public static UUID getCurrentUserIdOrThrow() {
-		// UnauthorizedException 클래스가 없어 컴파일 에러 발생 -> CustomException으로 대체
-		return getCurrentUserId().orElseThrow(() -> new CustomException("UnauthorizedException"));
+		return getCurrentUserId().orElseThrow(() -> new CustomException(GlobalErrorCode.UNAUTHORIZED));
 	}
 
 	public static Optional<String> getCurrentUsername() {

--- a/src/main/java/org/pgsg/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/pgsg/config/security/CustomAccessDeniedHandler.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.pgsg.common.exception.ErrorConfigProperties;
 import org.pgsg.common.exception.ErrorConfigProperties.ErrorDetail;
+import org.pgsg.common.exception.GlobalErrorCode;
 import org.pgsg.common.response.ErrorResponse;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
@@ -31,24 +32,24 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
                        AccessDeniedException accessDeniedException) throws IOException {
 
         String traceId = MDC.get("traceId");
-
-        ErrorDetail detail = errorConfigProperties.getConfigs().get("AccessDeniedException");
+        String errorKey = GlobalErrorCode.ACCESS_DENIED.getErrorKey();
+        ErrorDetail detail = errorConfigProperties.getConfigs().get(errorKey);
 
         int status = (detail != null) ? detail.getStatus() : 403;
         String code = (detail != null) ? detail.getCode() : "C003";
         String message = (detail != null) ? detail.getMessage() : "접근 권한이 없습니다.";
 
-        // traceId가 없을 경우를 대비해 안전하게 로그 기록
-        log.warn("[TraceID: {}] Access Denied: Method: {}, URI: {}, Message: {}",
+        log.warn("[TraceID: {}] Access Denied: Method: {}, URI: {}, ErrorKey: {}, Message: {}",
                 traceId != null ? traceId : "N/A",
                 request.getMethod(),
                 request.getRequestURI(),
+                errorKey,
                 accessDeniedException.getMessage());
 
         ErrorResponse errorResponse = ErrorResponse.of(
-            HttpStatus.valueOf(status),
-            code,
-            message
+                HttpStatus.valueOf(status),
+                code,
+                message
         );
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);


### PR DESCRIPTION
### 작업 배경
- 기존 application-error.yaml의 문자열(String) 키 값에만 의존하는 방식은 오타나 키 누락 발생 시 컴파일 타임에 에러를 인지할 수 없어 런타임 장애의 위험이 존재함.
- 예외 처리를 위해 도메인 계층에서 Spring Framework의 HttpStatus를 직접 참조하게 되면 외부 웹 기술에 의존하게 됨. 도메인 모델의 순수성을 유지하고 의존성을 역전시키기 위한 구조 개선이 필요함.

### 작업 내용
- 공통 모듈 버전업: v0.0.1 -> v.0.1.0
- 각 마이크로서비스 도메인에서 외부 기술 의존 없이 자체적인 에러 규격을 정의할 수 있도록 ErrorCode 인터페이스 도입.
- 시스템 전역에서 공통으로 사용되는 GlobalErrorCode 코드(예: 인증/인가 실패 등) 정의.
- CustomException, GlobalExceptionAdviceImpl, SecurityUtil, CustomAccessDeniedHandler 내부 로직을 Enum 기반으로 수정.

### 테스트 여부
- 거래 도메인에서 적용되는지 확인했습니다. ([관련 PR](https://github.com/89-49/trade-service/pull/8))

### 기타
- 공통 모듈 버전이 0.1.0으로 변경되었으므로, 해당 모듈을 사용하는 타 도메인 서비스의 빌드 스크립트 의존성 버전 업데이트가 필요합니다.
- 향후 각 마이크로서비스 도메인에서 커스텀 예외를 만들 때, 이 공통 모듈의 ErrorCode 인터페이스를 구현(implements)하는 Enum을 생성하여 사용하면 됩니다.
- [가이드 문서](https://www.notion.so/teamsparta/Common-v0-1-0-3522dc3ef514808ba280cae46020370f?source=copy_link)

### 이슈
This closes #13 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 예외 처리 체계를 개선하여 타입 기반 오류 코드 도입 및 구조화된 매핑 적용
  * 유효성 검사 실패, 권한/접근 오류에 대한 명확한 에러 응답 추가
  * 미처리 예외에 대한 통일된 서버 오류 응답 처리 추가

* **Chores**
  * 프로젝트 버전을 0.1.0-SNAPSHOT으로 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->