### PR TITLE
chore: JsonConfig 설정 추가

### DIFF
--- a/src/main/java/org/pgsg/config/json/JsonConfig.java
+++ b/src/main/java/org/pgsg/config/json/JsonConfig.java
@@ -1,5 +1,6 @@
 package org.pgsg.config.json;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.pgsg.common.util.JsonUtil;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +17,8 @@ public class JsonConfig {
 		ObjectMapper om = new ObjectMapper();
 		om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		om.registerModule(new JavaTimeModule());
+		// 날짜를 숫자 배열로 나타내는 대신 ISO-8601 형식을 적용하기 위한 설정
+		om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 		return om;
 	}
 


### PR DESCRIPTION
### 작업 배경
- 응답 데이터에서 날짜가 숫자 배열 형식으로 반환되는 문제 수정

### 작업 내용
- JsonConfig에 날짜타입 데이터를 ISO-8601 포맷으로 출력하기 위한 설정 추가 

### 테스트 여부
- `gradle clean build` 수행 시 컴파일 에러가 발생하지 않음을 확인

### 기타
- 아직 merge되지 않은 브랜치가 있고, 해당 브랜치에서의 최신 버전이 0.2.7 버전이라 배포는 진행하지 않고 JsonConfig에 설정만 추가했습니다.
(dev 브랜치에서의 버전을 변경하지 않았기 때문에 이 pr에서의 공통 모듈의 버전은 0.2.6 버전입니다. 수정해야 할 경우 수정하겠습니다.)


### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #22 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * JSON 출력에서 날짜가 이제 ISO-8601 표준 형식으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->